### PR TITLE
Add theano-pymc v1.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,30 +11,37 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   entry_points:
     - theano-cache = bin.theano_cache:main
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
     - pip
     - python
-  run:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - python
     - setuptools
-    - six >=1.9.0
-    - numpy >=1.9.1
+    - wheel
+    - numpy
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
     - scipy >=0.14
-    - pygpu >=0.7.0,<0.8
-    - jax  # [py>=37 and not win]
+    #- six >=1.9.0
+    #- pygpu >=0.7.0,<0.8
+    #- jax  # [py>=37 and not win]
     - filelock
 
 test:
   imports:
     - theano
+  requires:
+    - pip
   commands:
+    - pip check
     - theano-cache help
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,10 +30,9 @@ requirements:
     - python
     - {{ pin_compatible('numpy') }}
     - scipy >=0.14
-    #- six >=1.9.0
-    #- pygpu >=0.7.0,<0.8
-    #- jax  # [py>=37 and not win]
     - filelock
+    # 2021/10/20: Anaconda disable jax package (for faster optimization) 
+    # until it gets available for all architectures
 
 test:
   imports:


### PR DESCRIPTION
Popularity:  79329 downloads -  theano-pymc  1.1.2  Fork of Theano for PyMC3. An optimizing compiler for evaluating mathematical expressions on CPUs and GPUs.
  license: BSD-3-Clause
Release date:  Jan 22, 2021, https://pypi.org/project/theano-pymc/#history
Bug Tracker: new open issues https://github.com/pymc-devs/Theano-PyMC/issues
Github releases:  https://github.com/pymc-devs/Theano-PyMC/releases
Upstream license: https://github.com/aesara-devs/aesara/blob/rel-1.1.2/doc/LICENSE.txt
Upstream setup file: https://github.com/aesara-devs/aesara/blob/rel-1.1.2/setup.py

The package theano-pymc is mentioned inside the packages:
pymc3 | 

Actions:
1. Add `skip: True  # [py<36]`
2. Add missing packages: `setuptools`, `wheel`, `numpy `
3. Update dependencies from the upstream source: 
- comment packages as they aren't mentioned in the upstream setup.py
```
    #- six >=1.9.0
    #- pygpu >=0.7.0,<0.8
    #- jax  # [py>=37 and not win]
```
4. Use `- {{ pin_compatible('numpy') }}`
5. Add `pip check`

Result:
- all-succeeded

NOTE: 
`theano-pymc` changed its name to `aesara `from the next release **2.0.0** 