### PR TITLE
theano-pymc 1.1.2 (py39-311 rebuild)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5da6c2242ea72a991c8446d7fe7d35189ea346ef7d024c890397011114bf10fc
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - theano-cache = bin.theano_cache:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,10 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - theano-cache = bin.theano_cache:main
+  # ModuleNotFoundError: No module named 'numpy.distutils'
+  # This project is archived by PyPI, but it is still used as a backend for pymc3.
+  # Won`t fix py>311 compatibility issues which appeared in versioneer and cmodule.py.
+  skip: true  # [py>311]
 
 requirements:
   build:
@@ -31,8 +35,6 @@ requirements:
     - numpy >=1.9.1
     - scipy >=0.14
     - filelock
-    # 2021/10/20: Anaconda disable jax package (for faster optimization) 
-    # until it gets available for all architectures
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ requirements:
     - numpy
   run:
     - python
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - numpy >=1.9.1
     - scipy >=0.14
     - filelock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,33 +1,34 @@
+{% set name = "Theano-PyMC" %}
 {% set version = "1.1.2" %}
 
 package:
-  name: theano-pymc
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/T/Theano-PyMC/Theano-PyMC-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name }}-{{ version }}.tar.gz
   sha256: 5da6c2242ea72a991c8446d7fe7d35189ea346ef7d024c890397011114bf10fc
 
 build:
   number: 0
-  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - theano-cache = bin.theano_cache:main
-  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - pip
     - python
-    - setuptools
     - wheel
+    - setuptools
     - numpy
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy >=1.9.1
     - scipy >=0.14
     - filelock
     # 2021/10/20: Anaconda disable jax package (for faster optimization) 
@@ -44,11 +45,15 @@ test:
 
 about:
   home: https://github.com/pymc-devs/Theano-PyMC
-  license: BSD-3-Clause
   summary: An optimizing compiler for evaluating mathematical expressions. Theano-PyMC is a fork of the Theano library maintained by the PyMC developers.
+  license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
-  dev_url: https://github.com/pymc-devs/Theano-PyMC/
-  doc_url: https://theano-pymc.readthedocs.io/en/latest/
+  description: |
+    Theano is a Python library that allows you to define, optimize, and efficiently evaluate
+    mathematical expressions involving multi-dimensional arrays. It is built on top of NumPy.
+  dev_url: https://github.com/pymc-devs/Theano-PyMC
+  doc_url: https://theano-pymc.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,15 +21,12 @@ build:
 
 requirements:
   build:
-    - {{ stdlib('c') }}
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
   host:
     - pip
     - python
     - wheel
     - setuptools
-    - numpy
+    - numpy 1.26.4
   run:
     - python
     - {{ compiler('c') }}
@@ -64,3 +61,6 @@ extra:
     - twiecki
     - ericmjl
     - brandonwillard
+  skip-lints:
+    - compilers_must_be_in_build
+    - patch_unnecessary


### PR DESCRIPTION
theano-pymc 1.1.2 

**Destination channel:** Defaults

### Links

- [PKG-9498]
- dev_url:        https://github.com/pymc-devs/Theano-PyMC//tree/rel-1.1.2
- conda_forge:    https://github.com/conda-forge/theano-pymc-feedstock
- pypi:           https://pypi.org/project/theano-pymc/1.1.2
- pypi inspector: https://inspector.pypi.io/project/theano-pymc/1.1.2

### Explanation of changes:

- new version number


[PKG-9498]: https://anaconda.atlassian.net/browse/PKG-9498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ